### PR TITLE
Create bibliography list template

### DIFF
--- a/custom-bibliographies.hbs
+++ b/custom-bibliographies.hbs
@@ -1,0 +1,34 @@
+{{!< default}}
+{{!-- The tag above means: insert everything in this file
+into the {body} of the default.hbs template --}}
+
+<article class="post-content {{post_class}} {{#unless feature_image}}no-image{{/unless}}">
+  {{#post}}
+    <header class="post-content-header">
+        <h1 class="post-content-title">{{title}}</h1>
+    </header>
+    {{#if feature_image}}
+    <div class="post-content-image">
+        <img class="kg-image" src="{{feature_image}}" alt="{{title}}" />
+    </div>
+    {{/if}}
+    <div class="post-content-body">
+        {{content}}
+    </div>
+  {{/post}}
+
+  {{#get "tags" filter="slug:>publication+slug:<=publication-x"}}
+    {{#foreach tags}}
+        {{> category}}
+        {{#get "posts" filter="tag:{{slug}}" order="published_at desc" limit="all"}}
+          <div class="post-content-body">
+            <ol reversed>
+              {{#foreach posts}}
+                  {{> "bibliography-list"}}
+              {{/foreach}}
+            </ol>
+          </div>
+        {{/get}}
+    {{/foreach}}
+  {{/get}}
+</article>

--- a/partials/bibliography-list.hbs
+++ b/partials/bibliography-list.hbs
@@ -1,0 +1,1 @@
+<li>{{excerpt}}</li>

--- a/partials/post-list.hbs
+++ b/partials/post-list.hbs
@@ -1,1 +1,1 @@
-<li>{{excerpt}} <a href="{{url}}">read on..</a></li>
+<li>{{excerpt}} <a href="{{url}}">More details...</a></li>

--- a/partials/post-list.hbs
+++ b/partials/post-list.hbs
@@ -1,1 +1,1 @@
-<li>{{excerpt}} <a href="{{url}}">More details...</a></li>
+<li>{{excerpt}} <a href="{{url}}">Details...</a></li>


### PR DESCRIPTION
I have created a template that produces exactly the same result as a publications template, but without the "Read on..." links at the end of the list. 

It is often the case that one wants to updload quickly, on a CV, or on a document, their list of publications. At present this could not be done efficiently, because the publication list has all the "Read on..." appended to it. These links are necessary in the website, of course. 

With the proposed new template, users are able to populate automatically a new page (which they do not need to link to the menu) which does exactly the same thing as the list of publications, but without the "Read on..." list. So they can quickly grab their list of publications from the page. Importantly. This page is automatically update any time a new post (publication) is published.